### PR TITLE
Rename to ember-cli-deploy-smart-compress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## v1.0.0 (2023-06-20)
 
 #### :rocket: Enhancement
-* [#1](https://github.com/ember-cli-deploy/ember-cli-deploy-compress/pull/1) Fork from Dockyard to ember-cli-deploy ([@lukemelia](https://github.com/lukemelia))
+* [#1](https://github.com/ember-cli-deploy/ember-cli-deploy-smart-compress/pull/1) Fork from Dockyard to ember-cli-deploy ([@lukemelia](https://github.com/lukemelia))
 
 #### Committers: 1
 - Luke Melia ([@lukemelia](https://github.com/lukemelia))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ember-cli-deploy-compress
+# ember-cli-deploy-smart-compress
 
 > An ember-cli-deploy plugin to compress files in-place choosing between gzip or brotli compression automatically based on your supported browsers.
 
@@ -18,7 +18,7 @@ For more information on what plugins are and how they work, please refer to the 
 Run the following command in your terminal:
 
 ```bash
-ember install ember-cli-deploy-compress
+ember install ember-cli-deploy-smart-compress
 ```
 
 Note that this addon requires at least node.js 14!
@@ -112,3 +112,7 @@ Since this is a node-only ember-cli addon, this package does not include many fi
 [1]: http://ember-cli-deploy.github.io/ember-cli-deploy/plugins/ "Plugin Documentation"
 [2]: https://github.com/zapnito/ember-cli-deploy-build "ember-cli-deploy-build"
 [3]: https://github.com/zapnito/ember-cli-deploy-s3 "ember-cli-deploy-s3"
+
+## Credits
+
+This project was forked from ember-cli-deploy-compress, maintained for several years by Dockyard. Thanks to the authors and maintainers!

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ember-cli-deploy/ember-cli-deploy-compress",
+  "name": "@ember-cli-deploy/ember-cli-deploy-smart-compress",
   "version": "1.0.0",
   "description": "Ember CLI Deploy plugin to compress files in gzip or brotli automatically depending on supported browsers (forked from Dockyard)",
   "keywords": [
     "ember-addon",
     "ember-cli-deploy-plugin"
   ],
-  "repository": "https://github.com/ember-cli-deploy/ember-cli-deploy-compress",
+  "repository": "https://github.com/ember-cli-deploy/ember-cli-deploy-smart-compress",
   "license": "MIT",
   "author": "Miguel Camba",
   "directories": {


### PR DESCRIPTION
Rename repository and package to ember-cli-deploy-smart-compress to be able to publish to npm